### PR TITLE
Refactor link checking into new class. Keeping article clean.

### DIFF
--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -164,55 +164,6 @@ module Goldencobra
       return html_to_render
     end
 
-
-    #get all links of a page and make a check for response status and time
-    def set_link_checker
-      links_to_check = []
-      status_for_links = {}
-      doc = Nokogiri::HTML(open(self.absolute_public_url))
-      #find all links and stylesheets
-      doc.css('a,link').each do |link|
-        links_to_check << add_link_to_checklist(link, "href")
-      end
-      #find all images and javascripts
-      doc.css('img,script').each do |link|
-        links_to_check << add_link_to_checklist(link,"src")
-      end
-      links_to_check = links_to_check.compact.delete_if{|a| a.blank?}
-      links_to_check.each_with_index do |link|
-        status_for_links[link] = {}
-        begin
-          start = Time.now
-          response = open(link)
-          status_for_links[link]["response_code"] = response.status[0]
-          status_for_links[link]["response_time"] = Time.now - start
-        rescue Exception  => e
-          status_for_links[link]["response_code"] = "404"
-          status_for_links[link]["response_error"] = e.to_s
-        end
-      end
-      self.link_checker = status_for_links
-    end
-
-    #helper method for finding links in html document
-    def add_link_to_checklist(link, src_type)
-      begin
-        if link.blank? || link[src_type].blank?
-          return nil
-        elsif link[src_type][0 .. 6] == "http://" || link[src_type][0 .. 6] == "https:/"
-          return "#{link[src_type]}"
-        elsif link[src_type] && link[src_type][0 .. 1] == "//"
-          return "http:/#{link[src_type][/.(.*)/m,1]}"
-        elsif link[src_type] && link[src_type][0] == "/"
-          return "#{Goldencobra::Setting.absolute_base_url}/#{link[src_type][/.(.*)/m,1]}"
-        elsif link[src_type] && !link[src_type].include?("mailto:")
-          return "#{self.absolute_public_url}/#{link[src_type]}"
-        end
-      rescue
-        return nil
-      end
-    end
-
     def comments_of_subarticles
       Goldencobra::Comment.where("article_id in (?)", self.subtree_ids)
     end

--- a/app/models/goldencobra/link_checker.rb
+++ b/app/models/goldencobra/link_checker.rb
@@ -1,0 +1,52 @@
+module Goldencobra
+  class LinkChecker
+    #get all links of a page and make a check for response status and time
+    def self.get_status_for_article(article)
+      links_to_check = []
+      status_for_links = {}
+      doc = Nokogiri::HTML(open(article.absolute_public_url))
+      #find all links and stylesheets
+      doc.css('a,link').each do |link|
+        links_to_check << self.add_link_to_checklist(link, "href")
+      end
+      #find all images and javascripts
+      doc.css('img,script').each do |link|
+        links_to_check << self.add_link_to_checklist(link,"src")
+      end
+      links_to_check = links_to_check.compact.delete_if{|a| a.blank?}
+      links_to_check.each_with_index do |link|
+        status_for_links[link] = {}
+        begin
+          start = Time.now
+          response = open(link)
+          status_for_links[link]["response_code"] = response.status[0]
+          status_for_links[link]["response_time"] = Time.now - start
+        rescue Exception  => e
+          status_for_links[link]["response_code"] = "404"
+          status_for_links[link]["response_error"] = e.to_s
+        end
+      end
+      status_for_links
+    end
+
+    #helper method for finding links in html document
+    def self.add_link_to_checklist(link, src_type)
+      begin
+        if link.blank? || link[src_type].blank?
+          return nil
+        elsif link[src_type][0 .. 6] == "http://" || link[src_type][0 .. 6] == "https:/"
+          return "#{link[src_type]}"
+        elsif link[src_type] && link[src_type][0 .. 1] == "//"
+          return "http:/#{link[src_type][/.(.*)/m,1]}"
+        elsif link[src_type] && link[src_type][0] == "/"
+          return "#{Goldencobra::Setting.absolute_base_url}/#{link[src_type][/.(.*)/m,1]}"
+        elsif link[src_type] && !link[src_type].include?("mailto:")
+          return "#{article.absolute_public_url}/#{link[src_type]}"
+        end
+      rescue
+        return nil
+      end
+    end
+
+  end
+end

--- a/lib/tasks/link_checker.rake
+++ b/lib/tasks/link_checker.rake
@@ -8,7 +8,8 @@ namespace :link_checker do
     if article_id.present?
       article = Goldencobra::Article.find(article_id)
       if article
-        article.set_link_checker
+        status = Goldencobra::LinkChecker.get_status_for_article(article)
+        article.link_checker = status
         article.save
       end
     else
@@ -22,7 +23,8 @@ namespace :link_checker do
   task :all => :environment do
     Goldencobra::Article.scoped.each do |article|
       begin
-        article.set_link_checker
+        status = Goldencobra::LinkChecker.get_status_for_article(article)
+        article.link_checker = status
         article.save
       rescue
         puts "Artikel konnte nicht geprüft werden: #{article.id}"


### PR DESCRIPTION
Article doesn't need to know how to check links. Article should only
know about itself. A new class named Goldencobra::LinkChecker can be
used for that instead. This way Goldencobra::Article stays clean and
obeys the Single Responsibility Principle.
