### PR TITLE
Extract open graph methods from Goldencobra::Article to Goldencobra::Metatag

### DIFF
--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -543,44 +543,11 @@ module Goldencobra
     end
 
     def verify_existence_of_opengraph_image
-      if Goldencobra::Metatag.where("article_id = ? AND name = 'OpenGraph Image'", self.id).count == 0
-        if self.article_images.any? && self.article_images.first.present? && self.article_images.first.image.present? && self.article_images.first.image.image.present?
-          meta_tag = Goldencobra::Metatag.where(article_id: self.id, name: "OpenGraph Image").first
-          meta_tag.value = "http://#{Goldencobra::Setting.for_key('goldencobra.url')}#{self.article_images.first.image.image.url}"
-          meta_tag.save
-        else
-          Goldencobra::Metatag.create(article_id: self.id,
-                                    name: "OpenGraph Image",
-                                    value: Goldencobra::Setting.for_key("goldencobra.facebook.opengraph_default_image"))
-        end
-      end
-
-
+      Goldencobra::Metatag.verify_existence_of_opengraph_image(self)
     end
 
     def set_default_opengraph_values
-      if Goldencobra::Metatag.where(article_id: self.id, name: 'OpenGraph Title').none?
-        Goldencobra::Metatag.create(name: 'OpenGraph Title',
-                                    article_id: self.id,
-                                    value: self.title)
-      end
-
-      if Goldencobra::Metatag.where(article_id: self.id, name: 'OpenGraph URL').none?
-        Goldencobra::Metatag.create(name: 'OpenGraph URL',
-                                    article_id: self.id,
-                                    value: self.absolute_public_url)
-      end
-
-      if Goldencobra::Metatag.where(article_id: self.id, name: 'OpenGraph Description').none?
-        if self.teaser.present?
-          value = self.teaser
-        else
-          value = self.content.present? ? self.content.truncate(200) : self.title
-        end
-        Goldencobra::Metatag.create(name: 'OpenGraph Description',
-                                    article_id: self.id,
-                                    value: value)
-      end
+      Goldencobra::Metatag.set_default_opengraph_values(self)
     end
 
     def notification_event_create

--- a/app/models/goldencobra/metatag.rb
+++ b/app/models/goldencobra/metatag.rb
@@ -1,4 +1,4 @@
-# == Schema Information
+# Schema Information
 #
 # Table name: goldencobra_metatags
 #
@@ -17,5 +17,44 @@ module Goldencobra
     attr_accessible :name, :value, :article_id
     belongs_to :article
     belongs_to :metatagable, polymorphic: true
+
+    def self.set_default_opengraph_values(article)
+      create_tag('OpenGraph Title', article.id, article.title)
+      create_tag('OpenGraph URL', article.id, article.absolute_public_url)
+
+      if article.teaser.present?
+        value = article.teaser
+      else
+        value = article.content.present? ? article.content.truncate(200) : article.title
+      end
+      create_tag('OpenGraph Description', article.id, value)
+    end
+
+    def self.verify_existence_of_opengraph_image(article)
+      unless tag_exists?(article.id, 'OpenGraph Image')
+        if article_has_image?(article)
+          meta_tag = Goldencobra::Metatag.where(article_id: article.id, name: "OpenGraph Image").first
+          meta_tag.value = "http://#{Goldencobra::Setting.for_key('goldencobra.url')}#{article.article_images.first.image.image.url}"
+          meta_tag.save
+        else
+          create_tag("OpenGraph Image", article.id, Goldencobra::Setting.for_key("goldencobra.facebook.opengraph_default_image"))
+        end
+      end
+    end
+
+    private
+    def self.create_tag(name, id, value)
+      unless tag_exists?(id, name)
+        Goldencobra::Metatag.create(name: name, article_id: id, value: value)
+      end
+    end
+
+    def self.article_has_image?(article)
+      article.article_images.any? && article.article_images.first.image.present? && article.article_images.first.image.image.present?
+    end
+
+    def self.tag_exists?(article_id, name)
+      Goldencobra::Metatag.where(article_id: article_id, name: name).any?
+    end
   end
 end


### PR DESCRIPTION
Closed the last Pull Request and openend a new one. The last one had some flaws.

This change replaces the implementations of the opengraph related methods inside Goldencobra::Article with calls to new class methods on Goldencobra::Metatag. Both OpenGraph methods in Goldencobra::Article created Goldencobra::Metatag objects so it makes no sense to keep that code inside the Article class. Furthermore the methods were optimized to make them more readable and easier to understand.
