### PR TITLE
Adds gem iconv as a dependency for gem Goldencobra.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
       geocoder
       geokit (= 1.7.1)
       i18n-active_record
+      iconv
       inherited_resources
       jquery-rails (= 2.1.4)
       liquid
@@ -288,6 +289,7 @@ GEM
     http_parser.rb (0.5.3)
     httpauth (0.2.1)
     i18n (0.6.9)
+    iconv (1.0.4)
     inherited_resources (1.4.1)
       has_scope (~> 0.6.0.rc)
       responders (~> 1.0.0.rc)

--- a/goldencobra.gemspec
+++ b/goldencobra.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |s|
   s.add_dependency "pdfkit"
   s.add_dependency 'wkhtmltopdf-binary'
   s.add_dependency 'rmagick'
+  s.add_dependency 'iconv'
   # s.add_dependency "wicked_pdf"
   s.add_development_dependency "mysql2"
   s.add_development_dependency 'annotate'


### PR DESCRIPTION
Iconv is used inside the model Goldencobra::Import. It is not a usually
installed gem and it wasn't listed in the dependencies. One couldn't
load the environment without this gem.
