### PR TITLE
Introduces a new UrlBuilder to create an article's public_url

### DIFF
--- a/app/models/goldencobra/article.rb
+++ b/app/models/goldencobra/article.rb
@@ -411,20 +411,7 @@ module Goldencobra
     end
 
     def public_url(with_prefix=true)
-      if self.startpage
-        if with_prefix
-          return "#{Goldencobra::Domain.current.try(:url_prefix)}/"
-        else
-          return "/"
-        end
-      else
-        a_url = "/#{self.path.select([:ancestry, :url_name, :startpage]).map{|a| a.url_name if !a.startpage}.compact.join("/")}"
-        if with_prefix
-          return "#{Goldencobra::Domain.current.try(:url_prefix)}#{a_url}"
-        else
-          return a_url
-        end
-      end
+      Goldencobra::UrlBuilder.new(self, with_prefix).article_path
     end
 
     def date_of_last_modified_child
@@ -440,19 +427,11 @@ module Goldencobra
     end
 
     def absolute_base_url
-      if Goldencobra::Setting.for_key("goldencobra.use_ssl") == "true"
-        "https://#{Goldencobra::Setting.for_key('goldencobra.url')}"
-      else
-        "http://#{Goldencobra::Setting.for_key('goldencobra.url')}"
-      end
+      Goldencobra::UrlBuilder.new(self).absolute_base_url
     end
 
     def absolute_public_url
-      if Goldencobra::Setting.for_key("goldencobra.use_ssl") == "true"
-        "https://#{Goldencobra::Setting.for_key('goldencobra.url')}#{self.public_url}"
-      else
-        "http://#{Goldencobra::Setting.for_key('goldencobra.url')}#{self.public_url}"
-      end
+      Goldencobra::UrlBuilder.new(self).absolute_public_url
     end
 
     def for_friendly_name

--- a/app/models/goldencobra/url_builder.rb
+++ b/app/models/goldencobra/url_builder.rb
@@ -1,0 +1,54 @@
+module Goldencobra
+  class UrlBuilder
+    def initialize(article, with_prefix=false)
+      @article = article
+      @with_prefix = with_prefix
+    end
+
+    def article_path
+      if @article.is_startpage?
+        remove_trailing_double_slashes("#{prefix + '/'}")
+      else
+        prefix + ancestry_path
+      end
+    end
+
+    def absolute_base_url
+      if Goldencobra::Setting.for_key("goldencobra.use_ssl") == "true"
+        "https://#{Goldencobra::Setting.for_key('goldencobra.url')}"
+      else
+        "http://#{Goldencobra::Setting.for_key('goldencobra.url')}"
+      end
+    end
+
+    def absolute_public_url
+      if Goldencobra::Setting.for_key("goldencobra.use_ssl") == "true"
+        "https://#{Goldencobra::Setting.for_key('goldencobra.url')}#{@article.article_path}"
+      else
+        "http://#{Goldencobra::Setting.for_key('goldencobra.url')}#{@article.article_path}"
+      end
+    end
+
+    private
+
+    def ancestry_path
+      @article.path.select([:ancestry, :url_name, :startpage]).inject(String.new) do |string, article|
+        unless article.startpage
+          string + article.url_name + '/'
+        end
+      end
+    end
+
+    def prefix
+      if @with_prefix
+        "#{Goldencobra::Domain.current.try(:url_prefix)}/"
+      else
+        ''
+      end
+    end
+
+    def remove_trailing_double_slashes(input)
+      input.gsub(/\/\/$/,'/')
+    end
+  end
+end

--- a/test/dummy/spec/models/url_builder_spec.rb
+++ b/test/dummy/spec/models/url_builder_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Goldencobra::UrlBuilder do
+
+  describe '#article_path' do
+
+    context 'without prefix' do
+
+      it 'returns / for a startpage' do
+        article = build_stubbed :article, startpage: true
+        builder  = Goldencobra::UrlBuilder.new(article, false)
+
+        url = builder.article_path
+
+        expect(url).to eq('/')
+      end
+
+      it 'returns the ancestry for an normal article' do
+        article = create :article, url_name: 'first'
+        child = create :article, ancestry: article.id, url_name: 'second'
+        grandson = create :article, ancestry: "#{article.id}/#{child.id}", url_name: 'third'
+        builder  = Goldencobra::UrlBuilder.new(grandson, false)
+
+        url = builder.article_path
+        
+        expect(url).to eq('first/second/third/')
+      end
+
+    end
+
+    context 'with prefix' do
+      
+      before(:each) do
+        Goldencobra::Domain.stub_chain(:current, :url_prefix).and_return('http://foo.bar')
+      end
+
+      it 'returns / for a startpage' do
+        article = build_stubbed :article, startpage: true
+        builder  = Goldencobra::UrlBuilder.new(article, true)
+
+        url = builder.article_path
+
+        expect(url).to eq('http://foo.bar/')
+      end
+
+      it 'returns the ancestry for an normal article' do
+        article = create :article, url_name: 'first'
+        child = create :article, ancestry: article.id, url_name: 'second'
+        grandson = create :article, ancestry: "#{article.id}/#{child.id}", url_name: 'third'
+        builder  = Goldencobra::UrlBuilder.new(grandson, true)
+
+        url = builder.article_path
+        
+        expect(url).to eq('http://foo.bar/first/second/third/')
+      end
+
+    end
+
+  end
+  
+end


### PR DESCRIPTION
Once again Goldencobra::Article doesn't need to know how to build a public url. There was too much logic inside article. This refactoring extracts the logic from Article and introduces it into a new class Goldencobra::UrlBuilder. Includes the unit tests for the new class.
