### PR TITLE
fix: fix article count in admin template index

### DIFF
--- a/admin/templates.rb
+++ b/admin/templates.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Goldencobra::Template, as: "Template" do
       link_to(t.articletypes.count, "/admin/articletypes?q%5Barticletype_templates_template_id_eq%5D=#{t.id}")
     end
     column :articles do |t|
-      t.articletypes.map(&:articles).flatten.uniq.count
+      Goldencobra::Article.where(template_file: t.layout_file_name).count
     end
     actions
   end


### PR DESCRIPTION
- the count should be the number of articles with a certain
  layout file instead of the number of articles of an article type

Fixes #134